### PR TITLE
Fix require

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,5 +1,5 @@
 /* Include the Security module, we will use this later to escape a HTML attribute*/
-var Security = require('ep_etherpad-lite/static/js/security.js'); 
+var Security = require('ep_etherpad-lite/static/js/security'); 
 
 /* Time silider detection from md_linkify */
 var timesliderRegexp = new RegExp(/p\/[^\/]*\/timeslider/g);


### PR DESCRIPTION
This makes it at least import properly on etherpad 1.6.1.

~~There still seems to be an issue with links, `[testing](http://go` somehow screws up some internal state and makes an editor unusable... Will look into that too.~~ nevermind, this was caused by another plugin